### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 Eli Yazdi and Thomas Smith
+Copyright (c) 2022 Eli Yazdi, Thomas Smith, Vu Trinh, Angelina Ilijevski
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2022 Eli Yazdi and Thomas Smith
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
@eliyazdi @thomasebsmith Your approval is needed

Licensing our software is an important step in becoming a mature organization. I believe that the MIT license is the best option for this project. Please see our [meeting notes](https://docs.google.com/presentation/d/1zK38xOiIaG-YE_WRLEEBhm5gFcFmC1T3E60nswZ1694/edit) for details. If you have any questions, feel free to message me on Slack or leave a comment on this pull request.

**Please comment on this pull request to approve this licensing change**. Otherwise, please comment what license you are willing to use, as currently there are no clear terms.